### PR TITLE
use maintained stretch-backports package

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,10 +7,8 @@ galaxy_info:
 dependencies:
   - role: ajsalminen.apt_source
     apt_source_config:
-      - source: deb http://ftp.se.debian.org/debian/ jessie main
-        key:
-          url: http://keyserver.ubuntu.com:11371/pks/lookup?op=get&search=0x75DDC3C4A499F1A18CB5F3C8CBF8D6FD518E17E1
-          id: 75DDC3C4A499F1A18CB5F3C8CBF8D6FD518E17E1
+      - source: deb http://ftp.funet.fi/pub/linux/mirrors/debian stretch-backports main
         packages:
-          - pattern: 'graphite-web python-django python-django-common python-django-tagging'
-            priority: 1001
+        - pattern: 'graphite-web python-whisper'
+          priority: 1001
+    when: ansible_distribution == "Debian" and ansible_distribution_release == "stretch"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
   notify: reload apache
 
 - name: Sync graphite database
-  command: graphite-manage syncdb --noinput
+  command: graphite-manage migrate --run-syncdb --noinput
   notify: reload apache
 
 - name: Make user _graphite the owner of graphite database

--- a/templates/apache_vhost.conf.j2
+++ b/templates/apache_vhost.conf.j2
@@ -6,8 +6,16 @@ Listen {{ graphite_vhost_ip }}:{{ graphite_port }}
     WSGIImportScript /usr/share/graphite-web/graphite.wsgi process-group=_graphite application-group=%{GLOBAL}
     WSGIScriptAlias / /usr/share/graphite-web/graphite.wsgi
 
-    Alias /content/ /usr/share/graphite-web/static/
-    <Location "/content/">
-	SetHandler None
+    Alias /static/ /usr/share/graphite-web/static/
+    <Location "/static/">
+        SetHandler None
     </Location>
+
+    ErrorLog ${APACHE_LOG_DIR}/graphite-web_error.log
+
+    # Possible values include: debug, info, notice, warn, error, crit,
+    # alert, emerg.
+    LogLevel warn
+
+    CustomLog ${APACHE_LOG_DIR}/graphite-web_access.log combined
 </VirtualHost>


### PR DESCRIPTION
Make changes to configs as outlined here:
https://sources.debian.org/src/graphite-web/1.0.2+debian-2.1/debian/graphite-web.NEWS/
Don't use python-django from backports, it seems not to work with
graphite.